### PR TITLE
Fix detection assertion in tests

### DIFF
--- a/plugin/src/test/scala/io/github/retronym/classpathshrinker/TestUtil.scala
+++ b/plugin/src/test/scala/io/github/retronym/classpathshrinker/TestUtil.scala
@@ -43,9 +43,16 @@ object TestUtil {
 
   def existsWarning(expectedWarning: String,
                     reporter: StoreReporter): Boolean = {
+    def hasDetectionWarning: Boolean = {
+      reporter.infos.exists { info =>
+        info.severity.id == reporter.WARNING.id &&
+          info.msg.startsWith("Detected the following unused classpath entries")
+      }
+    }
+
     reporter.infos.exists { info =>
-      info.severity.id == 1 && info.msg == expectedWarning
-    } || (expectedWarning.isEmpty && !reporter.infos.exists(_.severity == 0))
+      info.severity.id == reporter.WARNING.id && info.msg == expectedWarning
+    } || (expectedWarning.isEmpty && !hasDetectionWarning)
   }
 
   def prettyPrintErrors(reporter: StoreReporter): String = {


### PR DESCRIPTION
Make it work in cases when plugin should not generate warnings.

We need this PR as a part of our work with this plugin, because for now assertions are not actually working. This PR contain two points:
1) fix severity assertion to WARNING (instead of Int)
2) after that, we found 5 failing tests:
```
[error] Test io.github.retronym.classpathshrinker.ClassPathShrinkerSpec.Nothing is reported when everything is used in nested pkg object failed: assertion failed: Expected warning does not exist.Found:
[error] Class javax.annotation.Nullable not found - continuing with a stub.
[error] Expected:
[error] , took 0.271 sec
```

This happened because of guava has annotation Nullable and it is a warning in case of scala 2.11. So we fixed this also. 

cc @dkomanov