### PR TITLE
Use canonical path in classpath comparison

### DIFF
--- a/plugin/src/main/scala/io/github/retronym/classpathshrinker/ClassPathShrinker.scala
+++ b/plugin/src/main/scala/io/github/retronym/classpathshrinker/ClassPathShrinker.scala
@@ -27,7 +27,7 @@ class ClassPathShrinker(val global: Global) extends Plugin with Compat {
       override def run(): Unit = {
         super.run()
         val usedJars = findUsedJars
-        val usedClasspathStrings = usedJars.toList.map(_.toString).sorted
+        val usedClasspathStrings = usedJars.toList.map(_.canonicalPath).sorted
         val userClasspath = getClassPathFrom(settings)
         val userClasspathURLs = userClasspath
           .classesInExpandedPath(settings.classpath.value)
@@ -35,7 +35,7 @@ class ClassPathShrinker(val global: Global) extends Plugin with Compat {
         def toJar(u: URI): Option[File] =
           util.Try { new File(u) }.toOption.filter(_.getName.endsWith(".jar"))
         val userClasspathStrings =
-          userClasspathURLs.flatMap(x => toJar(x.toURI)).map(_.getPath).toList
+          userClasspathURLs.flatMap(x => toJar(x.toURI)).map(_.getCanonicalPath).toList
         val unneededClasspath =
           userClasspathStrings.filterNot(s => usedClasspathStrings.contains(s))
         if (unneededClasspath.nonEmpty) {

--- a/plugin/src/test/scala/io/github/retronym/classpathshrinker/ClassPathShrinkerSpec.scala
+++ b/plugin/src/test/scala/io/github/retronym/classpathshrinker/ClassPathShrinkerSpec.scala
@@ -269,4 +269,20 @@ class ClassPathShrinkerSpec {
     val allEntries = usedEntries ++ unusedEntries
     expectWarning(expectedWarning, extraClasspath = allEntries)(testCode)
   }
+
+  @Test
+  def `Nothing is reported even if commons has relative path`(): Unit = {
+    val testCode =
+      """package object demo {
+        |  class Bar {
+        |    org.apache.commons.lang3.ArrayUtils.EMPTY_BOOLEAN_ARRAY.length
+        |  }
+        |}
+      """.stripMargin
+    val unusedEntries = Seq()
+    val usedEntries = Coursier.getArtifactsRelative(Seq(commons))
+    val expectedWarning = ClassPathFeedback.createWarningMsg(unusedEntries)
+    val allEntries = usedEntries ++ unusedEntries
+    expectWarning(expectedWarning, extraClasspath = allEntries)(testCode)
+  }
 }


### PR DESCRIPTION
We are using relative classpaths in our build system and plugin doesn't detect them. So, we unified ClassPathShrinker in order to use absolute paths in usedClasspaths and userClasspaths

cc @dkomanov