### PR TITLE
use modern coursier (and other modern things too)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,9 @@ lazy val testDependencies = Seq(
   "junit" % "junit" % "4.12" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   // Depend on coursier to resolve unused classpath entries
-  "io.get-coursier" %% "coursier" % "1.0.3" % "test",
-  "io.get-coursier" %% "coursier-cache" % "1.0.3" % "test"
+  "io.get-coursier" %% "coursier" % "1.1.0-M7" % "test",
+  "io.get-coursier" %% "coursier-cache" % "1.1.0-M7" % "test",
+  "io.get-coursier" %% "coursier-scalaz-interop" % "1.1.0-M7" % "test"
 )
 
 lazy val publishSettings = Seq(
@@ -65,6 +66,7 @@ lazy val plugin = project.settings(
   name := "classpath-shrinker",
   scalaVersion in ThisBuild := "2.12.6",
   crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6"),
+  scalacOptions in Compile ++= Seq("-feature", "-deprecation"),
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   libraryDependencies ++= testDependencies,
   testOptions in Test ++= List(Tests.Argument("-v"), Tests.Argument("-s")),

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
-  scalaVersion in ThisBuild := "2.12.1",
-  crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.1"),
+  scalaVersion in ThisBuild := "2.12.6",
+  crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6"),
   organization in ThisBuild := "ch.epfl.scala"
 )
 
@@ -8,8 +8,8 @@ lazy val testDependencies = Seq(
   "junit" % "junit" % "4.12" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   // Depend on coursier to resolve unused classpath entries
-  "io.get-coursier" %% "coursier" % "1.0.0-M15" % "test",
-  "io.get-coursier" %% "coursier-cache" % "1.0.0-M15" % "test"
+  "io.get-coursier" %% "coursier" % "1.0.3" % "test",
+  "io.get-coursier" %% "coursier-cache" % "1.0.3" % "test"
 )
 
 lazy val publishSettings = Seq(
@@ -63,8 +63,8 @@ val scalaPartialVersion =
 
 lazy val plugin = project.settings(
   name := "classpath-shrinker",
-  scalaVersion in ThisBuild := "2.12.1",
-  crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.1"),
+  scalaVersion in ThisBuild := "2.12.6",
+  crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6"),
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   libraryDependencies ++= testDependencies,
   testOptions in Test ++= List(Tests.Argument("-v"), Tests.Argument("-s")),

--- a/plugin/src/main/scala/io/github/retronym/classpathshrinker/ClassPathFeedback.scala
+++ b/plugin/src/main/scala/io/github/retronym/classpathshrinker/ClassPathFeedback.scala
@@ -4,7 +4,7 @@ object ClassPathFeedback {
   def createWarningMsg(unusedEntries: Seq[String]): String = {
     if (unusedEntries.isEmpty) ""
     else {
-      val entries = unusedEntries.mkString("\n")
+      val entries = unusedEntries.filter(_.endsWith(".jar")).mkString("\n")
       s"Detected the following unused classpath entries: \n$entries"
     }
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
the main goal here is the coursier version bump, because
we want to include classpath-shrinker in the Scala community build,
and coursier is on a more modern version there

the other version bumps are just gravy

the change to ClassPathFeedback.scala is to fix test failures (induced by the coursier version bump) such
as the following:

```
[error] Detected the following unused classpath entries:
[error] /Users/tisue/.coursier/cache/v1/https/repo1.maven.org/maven2/com/google/guava/guava/21.0/guava-21.0.jar
[error] Expected:
[error] Detected the following unused classpath entries:
[error] /Users/tisue/.coursier/cache/v1/https/repo1.maven.org/maven2/com/google/guava/guava/21.0/guava-21.0.jar
[error] /Users/tisue/.coursier/cache/v1/https/repo1.maven.org/maven2/com/google/guava/guava/21.0/guava-21.0.pom
```

references https://github.com/scala/community-builds/pull/770